### PR TITLE
add a way to costumize targetNamespace and fix the one that is used by default

### DIFF
--- a/server/src/main/java/com/nortal/jroad/wsdl/XTeeWsdlDefinition.java
+++ b/server/src/main/java/com/nortal/jroad/wsdl/XTeeWsdlDefinition.java
@@ -54,6 +54,10 @@ public class XTeeWsdlDefinition implements Wsdl11Definition, InitializingBean {
 
   @Resource(name = "xteeDatabase")
   private String xRoadDatabase;
+
+  @Resource(name = "xRoadTargetNamespace")
+  private String xRoadTargetNamespace;
+
   @Resource
   private XTeeEndpointMapping xRoadEndpointMapping;
 
@@ -137,7 +141,9 @@ public class XTeeWsdlDefinition implements Wsdl11Definition, InitializingBean {
 
     setRequestSuffix(SuffixBasedMessagesProvider.DEFAULT_REQUEST_SUFFIX);
     setResponseSuffix(SuffixBasedMessagesProvider.DEFAULT_RESPONSE_SUFFIX);
-    delegate.setTargetNamespace("http://" + xRoadDatabase + ".x-road.eu");
+
+    String targetNamespace = (xRoadTargetNamespace != null) ?xRoadTargetNamespace : "http://"+xRoadDatabase+".x-road.ee/producer/";
+    delegate.setTargetNamespace(targetNamespace);
 
     if (!StringUtils.hasText(delegate.getTargetNamespace()) && typesProvider.getSchemaCollection() != null
         && typesProvider.getSchemaCollection().getXsdSchemas().length > 0) {

--- a/server/src/main/java/com/nortal/jroad/wsdl/XTeeWsdlDefinition.java
+++ b/server/src/main/java/com/nortal/jroad/wsdl/XTeeWsdlDefinition.java
@@ -142,7 +142,7 @@ public class XTeeWsdlDefinition implements Wsdl11Definition, InitializingBean {
     setRequestSuffix(SuffixBasedMessagesProvider.DEFAULT_REQUEST_SUFFIX);
     setResponseSuffix(SuffixBasedMessagesProvider.DEFAULT_RESPONSE_SUFFIX);
 
-    String targetNamespace = (xRoadTargetNamespace != null) ?xRoadTargetNamespace : "http://"+xRoadDatabase+".x-road.ee/producer/";
+    String targetNamespace = (xRoadTargetNamespace != null) ?xRoadTargetNamespace : "http://" + xRoadDatabase + ".x-road.eu";
     delegate.setTargetNamespace(targetNamespace);
 
     if (!StringUtils.hasText(delegate.getTargetNamespace()) && typesProvider.getSchemaCollection() != null


### PR DESCRIPTION
…ise_parimad_praktikad_ja_tuupilised_vead_v1.0.pdf

namespace has to be:"http://NAME-OF-XROAD-DB.xroad.ee/producer/". So I changed the default and introduced a new configuration item xRoadTargetNamespace to overwrite the default