### PR TITLE
Allow adding custom consumer to client generated from wsdl

### DIFF
--- a/typegen/src/main/resources/DatabaseImplTemplate.txt
+++ b/typegen/src/main/resources/DatabaseImplTemplate.txt
@@ -2,6 +2,7 @@ package ${databaseClass.packageName};
 
 import com.nortal.jroad.client.exception.XRoadServiceConsumptionException;
 import com.nortal.jroad.client.service.${databaseClass.baseImplementationName};
+import com.nortal.jroad.client.service.consumer.XRoadConsumer;
 import com.nortal.jroad.model.XRoadMessage;
 import com.nortal.jroad.model.XmlBeansXRoadMessage;
 import org.springframework.stereotype.Service;
@@ -34,4 +35,7 @@ public class ${databaseClass.implementationName} extends ${databaseClass.baseImp
 </#list>
 </#list>
 
+  public void setXRoadConsumer(XRoadConsumer consumer) {
+    this.xRoadConsumer = consumer;
+  }
 }

--- a/typegen/src/main/resources/DatabaseTemplate.txt
+++ b/typegen/src/main/resources/DatabaseTemplate.txt
@@ -1,6 +1,7 @@
 package ${databaseClass.packageName};
 
 import com.nortal.jroad.client.exception.XRoadServiceConsumptionException;
+import com.nortal.jroad.client.service.consumer.XRoadConsumer;
 
 /**
  * <code>${databaseClass.database}</code> X-road database.
@@ -22,4 +23,5 @@ public interface ${databaseClass.interfaceName} {
 </#list>
 </#list>
 
+  void setXRoadConsumer(XRoadConsumer consumer);
 }


### PR DESCRIPTION
Currently database classes generated from DatabaseTemplate.txt hide XRoadConsumer and don't allow setting custom XRoadConsumers. Setting xRoad client based consumers is needed for example if there are multiple xRoad clients in a project and they need to have different timeouts or custom consumer functionality.