### PR TITLE
no need to write stackTrace into system.out

### DIFF
--- a/client-transport/src/main/java/com/nortal/jroad/client/service/consumer/StandardXRoadConsumer.java
+++ b/client-transport/src/main/java/com/nortal/jroad/client/service/consumer/StandardXRoadConsumer.java
@@ -145,7 +145,6 @@ public class StandardXRoadConsumer extends WebServiceGatewaySupport implements X
                                                                       finalCallback,
                                                                       finalExtractor);
     } catch (Exception e) {
-      e.printStackTrace();
       XRoadServiceConsumptionException consumptionException = resolveException(e, xroadServiceConfiguration);
 
       if (consumptionException != null) {


### PR DESCRIPTION
It is not needed to print stack trace into application server console, better to print into log file or handle wrapping exception. 